### PR TITLE
Add FastAPI pipeline and server entrypoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,3 +87,6 @@ wasabi==1.1.3
 wcwidth==0.2.13
 weasel==0.4.1
 wrapt==1.17.2
+fastapi==0.111.0
+uvicorn==0.29.0
+streamlit==1.35.0

--- a/screening_agent/main.py
+++ b/screening_agent/main.py
@@ -1,0 +1,5 @@
+import uvicorn
+from screening_agent.pipeline import app
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/screening_agent/pipeline.py
+++ b/screening_agent/pipeline.py
@@ -1,0 +1,75 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import FileResponse
+import os
+import sys
+
+# Add modules folder to path so existing absolute imports work
+MODULES_DIR = os.path.join(os.path.dirname(__file__), "modules")
+if MODULES_DIR not in sys.path:
+    sys.path.append(MODULES_DIR)
+
+from screening_agent.modules.feature_generator import generate_features
+from screening_agent.modules.scoring import run_scoring
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SCHEMA_DIR = os.path.join(ROOT_DIR, 'data', 'outputs', 'feature_schemas')
+SCORING_DIR = os.path.join(ROOT_DIR, 'data', 'outputs', 'scoring_sheets')
+RESUME_BASE_DIR = os.path.join(ROOT_DIR, 'data', 'resumes')
+
+app = FastAPI()
+
+
+def _schema_path(job_id: str) -> str:
+    return os.path.join(SCHEMA_DIR, f"{job_id}_features.json")
+
+
+def _results_path(job_id: str) -> str:
+    return os.path.join(SCORING_DIR, f"{job_id}_scored_candidates.xlsx")
+
+
+@app.post('/jobs')
+async def create_job(jd: str, checklist: str | None = None):
+    """Generate scoring schema for a new job."""
+    schema_path = generate_features(jd, checklist)
+    job_id = os.path.basename(schema_path).split('_')[0]
+    return {"job_id": job_id}
+
+
+@app.post('/jobs/{job_id}/resumes')
+async def upload_resumes(job_id: str, files: list[UploadFile] = File(...)):
+    """Upload resumes for a job."""
+    dest_dir = os.path.join(RESUME_BASE_DIR, job_id)
+    os.makedirs(dest_dir, exist_ok=True)
+    saved = []
+    for file in files:
+        dest_path = os.path.join(dest_dir, file.filename)
+        with open(dest_path, 'wb') as f:
+            f.write(await file.read())
+        saved.append(file.filename)
+    return {"uploaded": saved}
+
+
+@app.post('/jobs/{job_id}/score')
+async def score_job(job_id: str):
+    """Run scoring for uploaded resumes."""
+    schema_path = _schema_path(job_id)
+    resumes_dir = os.path.join(RESUME_BASE_DIR, job_id)
+    if not os.path.exists(schema_path):
+        raise HTTPException(status_code=404, detail='Job not found')
+    if not os.path.isdir(resumes_dir):
+        raise HTTPException(status_code=404, detail='No resumes uploaded')
+
+    run_scoring(schema_path, resumes_dir)
+    result_path = _results_path(job_id)
+    if not os.path.exists(result_path):
+        raise HTTPException(status_code=500, detail='Scoring failed')
+    return {"result_path": result_path}
+
+
+@app.get('/jobs/{job_id}/results')
+async def get_results(job_id: str):
+    """Download scoring results."""
+    result_path = _results_path(job_id)
+    if not os.path.exists(result_path):
+        raise HTTPException(status_code=404, detail='Results not found')
+    return FileResponse(result_path, filename=os.path.basename(result_path))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,77 @@
+import streamlit as st
+import requests
+
+API_URL = "http://localhost:8000"
+
+st.title("Screening Agent UI")
+
+# Initialize session state
+if "job_id" not in st.session_state:
+    st.session_state.job_id = None
+if "results_ready" not in st.session_state:
+    st.session_state.results_ready = False
+
+if st.session_state.job_id is None:
+    st.header("Create Job")
+    jd_file = st.file_uploader("Job Description (.txt)", type=["txt"])
+    checklist_file = st.file_uploader("Checklist (.txt, optional)", type=["txt"])
+    if st.button("Create Job"):
+        if jd_file is None:
+            st.error("Please upload a job description text file.")
+        else:
+            jd_text = jd_file.read().decode("utf-8")
+            checklist_text = checklist_file.read().decode("utf-8") if checklist_file else None
+            try:
+                resp = requests.post(f"{API_URL}/jobs", json={"jd": jd_text, "checklist": checklist_text})
+                resp.raise_for_status()
+                job_id = resp.json().get("job_id")
+                st.session_state.job_id = job_id
+                st.success(f"Job created with ID: {job_id}")
+            except Exception as e:
+                st.error(f"Job creation failed: {e}")
+else:
+    job_id = st.session_state.job_id
+    st.success(f"Current Job ID: {job_id}")
+
+    st.header("Upload Resumes")
+    resumes = st.file_uploader("Resumes", type=["pdf", "docx", "txt"], accept_multiple_files=True)
+    if st.button("Upload Resumes"):
+        if not resumes:
+            st.error("Select at least one resume file to upload.")
+        else:
+            files = [("files", (r.name, r.read(), r.type or "application/octet-stream")) for r in resumes]
+            try:
+                resp = requests.post(f"{API_URL}/jobs/{job_id}/resumes", files=files)
+                resp.raise_for_status()
+                uploaded = resp.json().get("uploaded", [])
+                st.success(f"Uploaded {len(uploaded)} resume(s).")
+            except Exception as e:
+                st.error(f"Upload failed: {e}")
+
+    if st.button("Run Scoring"):
+        try:
+            resp = requests.post(f"{API_URL}/jobs/{job_id}/score")
+            resp.raise_for_status()
+            st.session_state.results_ready = True
+            st.success("Scoring completed. You can download the results below.")
+        except Exception as e:
+            st.error(f"Scoring failed: {e}")
+
+    if st.session_state.results_ready:
+        if st.button("Download Results"):
+            try:
+                resp = requests.get(f"{API_URL}/jobs/{job_id}/results")
+                resp.raise_for_status()
+                st.download_button(
+                    label="Download Excel",
+                    data=resp.content,
+                    file_name=f"{job_id}_scored_candidates.xlsx",
+                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
+            except Exception as e:
+                st.error(f"Download failed: {e}")
+
+    if st.button("Reset Job"):
+        st.session_state.job_id = None
+        st.session_state.results_ready = False
+        st.experimental_rerun()


### PR DESCRIPTION
## Summary
- implement screening pipeline API using FastAPI
- add API server entrypoint
- include FastAPI and Uvicorn in requirements
- add Streamlit-based UI to submit job description, resumes, and download results

## Testing
- `pip install uvicorn==0.29.0 fastapi==0.111.0`
- `pip install streamlit==1.35.0`
- `python -m screening_agent.main --help` (server started successfully and was interrupted)


------
https://chatgpt.com/codex/tasks/task_e_684c8e2b526083328eb5859a8583e00a